### PR TITLE
fix: pkg: update the licenses files

### DIFF
--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,4 +1,5 @@
-Copyright (c) <year> <owner>.
+Copyright (c) 2012-2018 Valentin Lab
+Copyright (c) 2018-2024 Stephen Arnold <sarnold@vctlabs.com>
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Masen Furer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR to update/fix the files in the `LICENSES` directory, especially:

* MIT exist in the SPDX License List, so no need to prefix the filename with `LicenseRef-`: 

According to the [Reuse spec](https://reuse.software/spec-3.3/):

> Each License File MUST be placed in the LICENSES/ directory in the root of the Project. The name of the License File MUST be the SPDX License Identifier of the license followed by an appropriate file extension (example: LICENSES/GPL-3.0-or-later.txt). The License File MUST be in plain text format.
>
> If a license does not exist in the SPDX License List, its SPDX License Identifier MUST be LicenseRef-[idstring] as defined by the SPDX Specification, Clause 10 available at https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/.

* Copyright lines specified in the `BSD-3-Clause` file


It would greatly help to integrate to integrate this PR in a new release, so that I can update the [PKGBUILD on Arch Linux User Repositories](https://aur.archlinux.org/packages/python-gitchangelog) and comply with the [guidelines](https://wiki.archlinux.org/title/PKGBUILD#license).